### PR TITLE
Fix slider bound values & bubble display value

### DIFF
--- a/Droid/Activities/BrowseItemDetailActivity.cs
+++ b/Droid/Activities/BrowseItemDetailActivity.cs
@@ -31,8 +31,8 @@ namespace XamControls.Droid
 
             slider = FindViewById<Controls.FluidSlider>(Resource.Id.fluidSlider);
 
-            slider.From = 0;
-            slider.To = 500;
+            slider.From = 100;
+            slider.To = 400;
             slider.SelectedValue = 250;
             slider.ColorBar = this.BaseContext.Resources.GetColor(Resource.Color.primary);
             //slider.ColorBubble = this.BaseContext.Resources.GetColor(Resource.Color.primary);

--- a/Droid/Controls/FluidSlider/FluidSlider.cs
+++ b/Droid/Controls/FluidSlider/FluidSlider.cs
@@ -318,12 +318,12 @@ namespace XamControls.Droid.Controls
 
         private float GetCurentValue()
         {
-            return (float)Math.Round(position * (Math.Abs(To - From)));
+			return (float)Math.Round(position * (Math.Abs(To - From)) + From);
         }
 
         private void SetCurrentValue(float value)
         {
-            position = (float)(value / Math.Abs(To - From));
+			position = (float)((value - From) / Math.Abs(To - From));
         }
 
         private void UpdatePosition(float value)

--- a/iOS/Controls/FluidSlider/Slider.cs
+++ b/iOS/Controls/FluidSlider/Slider.cs
@@ -8,6 +8,12 @@ namespace XamControls.iOS.Controls
 {
     public class Slider : UIControl
     {
+		public const int DEFAULT_START = 0;
+		public const int DEFAULT_END = 100;
+
+		public const int DEFAULT_MAX_FRACTION_DIGITS = 0;
+		public const int DEFAULT_MAX_INTEGER_DIGITS = 3;
+
         private float kBlurRadiusDefault = 12;
         private float kBlurRadiusIphonePlus = 18;
 
@@ -57,6 +63,33 @@ namespace XamControls.iOS.Controls
 
         public Action<Slider> DidBeginTracking;
         public Action<Slider> DidEndTracking;
+
+		private int from = DEFAULT_START;
+		public int From 
+		{
+			get { return from; }
+			set 
+			{
+				from = value;
+				SetMinimumLabelAttributedText(new NSAttributedString(from.ToString(), foregroundColor: UIColor.White));
+				UpdateValueViewText();
+			}
+		}
+
+		private int to = DEFAULT_END;
+		public int To
+		{
+			get { return to; }
+			set 
+			{
+				to = value;
+				SetMaximumLabelAttributedText(new NSAttributedString(to.ToString(), foregroundColor: UIColor.White));
+				UpdateValueViewText();
+			}
+		}
+
+		public int DisplayValueMaximumFractionDigits = DEFAULT_MAX_FRACTION_DIGITS;
+		public int DisplayValueMaximumIntegerDigits = DEFAULT_MAX_INTEGER_DIGITS;
 
         private float contentViewCornerRadius = 8f;
         public float ContentViewCornerRadius
@@ -189,8 +222,8 @@ namespace XamControls.iOS.Controls
             valueView.UserInteractionEnabled = false;
             valueView.AnimationFrame = RedrawFilterView;
 
-            SetMinimumLabelAttributedText(new NSAttributedString("0", foregroundColor: UIColor.White));
-            SetMaximumLabelAttributedText(new NSAttributedString("1", foregroundColor: UIColor.White));
+			SetMinimumLabelAttributedText(new NSAttributedString(From.ToString(), foregroundColor: UIColor.White));
+			SetMaximumLabelAttributedText(new NSAttributedString(To.ToString(), foregroundColor: UIColor.White));
 
             UpdateValueViewColor();
             UpdateValueViewText();
@@ -383,9 +416,9 @@ namespace XamControls.iOS.Controls
         public NSAttributedString AttributedTextForFraction(float frag)
         {
             var formatter = new NSNumberFormatter();
-            formatter.MaximumFractionDigits = 2;
-            formatter.MaximumIntegerDigits = 0;
-            var str = formatter.StringFromNumber((NSNumber)frag) ?? "";
+			formatter.MaximumFractionDigits = DisplayValueMaximumFractionDigits;
+			formatter.MaximumIntegerDigits = DisplayValueMaximumIntegerDigits;
+			var str = formatter.StringFromNumber(frag * Math.Abs(To - From) + From) ?? "";
             return new NSAttributedString(str);
         }
 

--- a/iOS/ViewControllers/DetailViewControllers/BrowseItemDetailViewController.cs
+++ b/iOS/ViewControllers/DetailViewControllers/BrowseItemDetailViewController.cs
@@ -23,7 +23,9 @@ namespace XamControls.iOS
             slider.ValueViewColor = UIColor.White;
             slider.ContentViewColor = UIColor.FromRGB(52 , 152 , 219 );
             slider.Fraction = 0.5f;
-            slider.Frame = new CoreGraphics.CGRect(20, 180, this.View.Bounds.Width - 40, 40);
+			slider.From = 5;
+			slider.To = 25;
+            slider.Frame = new CoreGraphics.CGRect(20, 220, this.View.Bounds.Width - 40, 40);
             slider.ContentViewCornerRadius = 8;
             //slider.BackgroundColor = UIColor.Gray;
 


### PR DESCRIPTION
iOS Fluid Slider bug (not fixed): bubble value cannot show the bound value when dragging to one end, but after releasing it works correctly